### PR TITLE
link extension key in client details to extension history

### DIFF
--- a/Resources/Private/Templates/Client/Show.html
+++ b/Resources/Private/Templates/Client/Show.html
@@ -88,7 +88,9 @@
 					<monitor:additionalExtensionData as="extra" client="{client.uid}" extension="{extension.uid}">
 						<tr class="{f:if(condition:extra.is_loaded,then:'',else:'t3-page-ce-hidden')}{f:if(condition:extension.insecure,then:'danger',else:'')}">
 							<td>
-								<span data-toggle="tooltip" data-title="{extension.title}" data-placement="right"> {extension.name} </span>
+								<span data-toggle="tooltip" data-title="{extension.title}" data-placement="right">
+									<f:link.action action="show" controller="Extension" arguments="{extension:'{extension.name}'}">{extension.name}</f:link.action>
+								</span>
 							</td>
 							<td>{extension.version}</td>
 							<td>


### PR DESCRIPTION
link extension key in client details to extension history similar to the list of extensions view to get faster access to the update history