### PR TITLE
[BUGFIX] Handle arrays in returnUrl

### DIFF
--- a/Classes/ViewHelpers/EditRecordViewHelper.php
+++ b/Classes/ViewHelpers/EditRecordViewHelper.php
@@ -56,10 +56,31 @@ class EditRecordViewHelper extends AbstractViewHelper implements CompilableInter
                 'tools_T3monitoringT3monitor');
 
         $vars = GeneralUtility::_GPmerged('tx_t3monitoring_tools_t3monitoringt3monitor');
-        foreach ($vars as $key => $value) {
-            $parameters['returnUrl'] .= sprintf('&tx_t3monitoring_tools_t3monitoringt3monitor[%s]=%s', $key, $value);
-        }
+        $parameters['returnUrl'] .= self::buildReturnUrl($vars);
 
         return BackendUtility::getModuleUrl('record_edit', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string The returnUrl
+     */
+    protected function buildReturnUrl($parameters)
+    {
+        $returnUrl = '';
+
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
+                foreach ($value as $name => $property) {
+                    $returnUrl .= sprintf('&tx_t3monitoring_tools_t3monitoringt3monitor[%s][%s]=%s', $key,
+                        $name, $property);
+                }
+            } else {
+                $returnUrl .= sprintf('&tx_t3monitoring_tools_t3monitoringt3monitor[%s]=%s', $key, $value);
+            }
+        }
+
+        return $returnUrl;
     }
 }

--- a/Classes/ViewHelpers/EditRecordViewHelper.php
+++ b/Classes/ViewHelpers/EditRecordViewHelper.php
@@ -52,25 +52,21 @@ class EditRecordViewHelper extends AbstractViewHelper implements CompilableInter
     ) {
         $parameters = GeneralUtility::explodeUrl2Array($arguments['parameters']);
 
-        $parameters['returnUrl'] = 'index.php?M=tools_T3monitoringT3monitor&moduleToken=' . FormProtectionFactory::get()->generateToken('moduleCall',
-                'tools_T3monitoringT3monitor');
-
-        $vars = GeneralUtility::_GPmerged('tx_t3monitoring_tools_t3monitoringt3monitor');
-        $parameters['returnUrl'] .= self::buildReturnUrl($vars);
+        $parameters['returnUrl'] = self::buildReturnUrl();
 
         return BackendUtility::getModuleUrl('record_edit', $parameters);
     }
 
     /**
-     * @param array $parameters
-     *
      * @return string The returnUrl
      */
-    protected function buildReturnUrl($parameters)
+    protected function buildReturnUrl()
     {
-        $returnUrl = '';
+        $returnUrl = 'index.php?M=tools_T3monitoringT3monitor&moduleToken=' . FormProtectionFactory::get()->generateToken('moduleCall',
+                'tools_T3monitoringT3monitor');
 
-        foreach ($parameters as $key => $value) {
+        $vars = GeneralUtility::_GPmerged('tx_t3monitoring_tools_t3monitoringt3monitor');
+        foreach ($vars as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $name => $property) {
                     $returnUrl .= sprintf('&tx_t3monitoring_tools_t3monitoringt3monitor[%s][%s]=%s', $key,


### PR DESCRIPTION
Fixing TYPO3 error "Exception while property mapping at property path "": The identity property "Array" is no UID." after editing a client from statistic index view.