### PR TITLE
[BUGFIX] Processing of extension information must be reversed

### DIFF
--- a/Classes/Service/DataIntegrity.php
+++ b/Classes/Service/DataIntegrity.php
@@ -27,9 +27,9 @@ class DataIntegrity
 
     public function invokeAfterExtensionImport()
     {
-        $this->usedExtensions();
-        $this->getNextSecureExtensionVersion();
         $this->getLatestExtensionVersion();
+        $this->getNextSecureExtensionVersion();
+        $this->usedExtensions();
     }
 
     protected function getLatestExtensionVersion()


### PR DESCRIPTION
First update extension infos, then search next secure ones and after that update usage.