### PR TITLE
Open client URL's in a new window

### DIFF
--- a/Resources/Private/Templates/Client/Show.html
+++ b/Resources/Private/Templates/Client/Show.html
@@ -28,7 +28,7 @@
 									http://*******.***
 								</f:then>
 								<f:else>
-									<f:link.external uri="{client.domain}">{client.domain}</f:link.external>
+									<f:link.external uri="{client.domain}" target="_blank">{client.domain}</f:link.external>
 								</f:else>
 							</f:if>
 						</td>


### PR DESCRIPTION
Client domains should be opened in a new tab and not in the frame of the TYPO3 backend.