### PR TITLE
[BUGFIX] Duplicate Label "insecure_extensions" in TCA #71

### DIFF
--- a/Configuration/TCA/tx_t3monitoring_domain_model_client.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_client.php
@@ -124,7 +124,7 @@ return [
         ],
         'outdated_core' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.insecure_extensions',
+            'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.outdated_core',
             'config' => [
                 'readOnly' => true,
                 'type' => 'check',


### PR DESCRIPTION
Before:
<img width="403" alt="bildschirmfoto 2017-09-29 um 21 53 24" src="https://user-images.githubusercontent.com/212705/31033529-b51691b8-a560-11e7-8532-10078102b06e.png">

After:
<img width="248" alt="bildschirmfoto 2017-09-29 um 21 53 42" src="https://user-images.githubusercontent.com/212705/31033528-b50c36c8-a560-11e7-93ac-9f45c086eedc.png">

