### PR TITLE
[BUGFIX] Fix css for data-tables in panels

### DIFF
--- a/Resources/Public/Css/t3monitoring.css
+++ b/Resources/Public/Css/t3monitoring.css
@@ -28,3 +28,11 @@
 .extension-list th.no-sorting {
     cursor: default;
 }
+
+.panel .table,
+.panel-collapse .table,
+.panel .table-fit,
+.panel-collapse .table-fit {
+    border: 0;
+    margin: 0;
+}


### PR DESCRIPTION
This fix the margin of data tables

Before:
<img width="997" alt="bildschirmfoto 2017-10-05 um 22 34 05" src="https://user-images.githubusercontent.com/212705/31251265-a91bfb20-aa1d-11e7-94aa-da189bae140e.png">

After:
<img width="992" alt="bildschirmfoto 2017-10-05 um 22 34 20" src="https://user-images.githubusercontent.com/212705/31251273-adbfa15e-aa1d-11e7-870f-40accd5cfb2d.png">

