### PR TITLE
[BUGFIX] Use QueryBilder instances only once 

### DIFF
--- a/Classes/Service/DataIntegrity.php
+++ b/Classes/Service/DataIntegrity.php
@@ -255,10 +255,8 @@ class DataIntegrity
             ->execute()
             ->fetchAll();
 
-        $queryBuilder = $connection->createQueryBuilder();
-        $queryBuilder2 = $connection->createQueryBuilder();
         foreach ($clients as $client) {
-            $countInsecure = $queryBuilder
+            $countInsecure = $connection->createQueryBuilder()
                 ->count('uid')
                 ->from('tx_t3monitoring_client_extension_mm')
                 ->leftJoin(
@@ -274,7 +272,7 @@ class DataIntegrity
                 )->execute()->fetchColumn(0);
 
             // count outdated extensions
-            $countOutdated = $queryBuilder2
+            $countOutdated = $connection->createQueryBuilder()
                 ->count('uid')
                 ->from('tx_t3monitoring_client_extension_mm')
                 ->leftJoin(

--- a/Classes/Service/DataIntegrity.php
+++ b/Classes/Service/DataIntegrity.php
@@ -256,7 +256,8 @@ class DataIntegrity
             ->fetchAll();
 
         foreach ($clients as $client) {
-            $countInsecure = $connection->createQueryBuilder()
+            $queryBuilder = $connection->createQueryBuilder();
+            $countInsecure = $queryBuilder
                 ->count('uid')
                 ->from('tx_t3monitoring_client_extension_mm')
                 ->leftJoin(
@@ -272,7 +273,8 @@ class DataIntegrity
                 )->execute()->fetchColumn(0);
 
             // count outdated extensions
-            $countOutdated = $connection->createQueryBuilder()
+            $queryBuilder2 = $connection->createQueryBuilder();
+            $countOutdated = $queryBuilder2
                 ->count('uid')
                 ->from('tx_t3monitoring_client_extension_mm')
                 ->leftJoin(


### PR DESCRIPTION
There seems to be a problem with doctrine's unique alias checker, when QueryBuilder instances are used multiple times.

The following error occured, when fetching client or extension data:

>  The given alias '`tx_t3monitoring_domain_model_extension`' is not unique in FROM and JOIN clause table. The currently registered aliases are: `tx_t3monitoring_client_extension_mm`, `tx_t3monitoring_domain_model_extension`. 

![bildschirmfoto 2018-04-30 um 15 34 01](https://user-images.githubusercontent.com/16088567/39429855-836bb6b0-4c8c-11e8-9d2e-803aca09be7b.png)

I could solve the problem by creating new QueryBuilder instances inside the `foreach` loop.