### PR TITLE
[TASK] Include extra dangers in report emails

### DIFF
--- a/Classes/Domain/Repository/ClientRepository.php
+++ b/Classes/Domain/Repository/ClientRepository.php
@@ -68,6 +68,7 @@ class ClientRepository extends BaseRepository
         $demand = $this->getFilterDemand();
         $demand->setWithInsecureCore(true);
         $demand->setWithInsecureExtensions(true);
+        $demand->setWithExtraDanger(true);
 
         $constraints[] = $query->logicalOr(
             $this->getConstraints($demand, $query)

--- a/Resources/Private/Templates/Notification/AdminEmail.txt
+++ b/Resources/Private/Templates/Notification/AdminEmail.txt
@@ -8,5 +8,7 @@ Monitoring report of your clients
 Insecure core: {f:if(condition:client.core.insecure,then:client.core.version)}
 Insecure extensions: <f:for each="{client.extensions}" as="e"><f:if condition="{e.insecure}">
  - {e.name} {e.version}</f:if></f:for>
+Extra dangers: <f:for each="{client.extraDangerAsArray}" as="value" key="key">
+ - {key}: {value}</f:for>
 
 </f:for>

--- a/Resources/Private/Templates/Notification/ClientEmail.txt
+++ b/Resources/Private/Templates/Notification/ClientEmail.txt
@@ -5,3 +5,5 @@ This is an automatically generated report for {client.domain}:
 Insecure core: {f:if(condition:client.core.insecure,then:client.core.version)}
 Insecure extensions: <f:for each="{client.extensions}" as="e"><f:if condition="{e.insecure}">
  - {e.name} {e.version}</f:if></f:for>
+Extra dangers: <f:for each="{client.extraDangerAsArray}" as="value" key="key">
+ - {key}: {value}</f:for>


### PR DESCRIPTION
When doing my first steps with t3monitoring, I had instances with "extra dangers". They are red in the backend, but I did not receive any reports, which confused me.

I think, the extra are important enough to trigger report emails and should be included in the mails.

It would be great to see this in your official version.