### PR TITLE
[BUGFIX] Update security news URLs after typo3.org relaunch

### DIFF
--- a/Classes/Controller/StatisticController.php
+++ b/Classes/Controller/StatisticController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace T3Monitor\T3monitoring\Controller;
 
 /*
@@ -78,8 +79,7 @@ class StatisticController extends BaseController
         $feedItems = null;
         if ($this->emConfiguration->getLoadBulletins()) {
             /** @var BulletinImport $bulletinImport */
-            $bulletinImport = GeneralUtility::makeInstance(BulletinImport::class,
-                'https://typo3.org/xml-feeds/security/1/rss.xml', 5);
+            $bulletinImport = GeneralUtility::makeInstance(BulletinImport::class, 'https://typo3.org/?type=101', 5);
             $feedItems = $bulletinImport->start();
         }
 

--- a/Resources/Private/Templates/Statistic/Index.html
+++ b/Resources/Private/Templates/Statistic/Index.html
@@ -206,7 +206,7 @@
                             </f:if>
                             </div>
                             <div class="panel-footer">
-                                <a href="https://typo3.org/teams/security/security-bulletins/" target="_blank"
+                                <a href="https://typo3.org/help/security-advisories/security/all/" target="_blank"
                                     class="t3-link">{f:translate(key:'bulletins.all')}</a>
                             </div>
                         </div>


### PR DESCRIPTION
The URLs to security news and RSS feed changed during typo3.org relaunch. In the current backend module, the feed shows all news and the link "All bulletins" opens a 404 error page.

This bugfix updates both URLs in your backend module.