### PR TITLE
[BUGFIX] Use <a> tag instead of <f:link.external> to not have problems with HTTPS links

### DIFF
--- a/Resources/Private/Templates/Statistic/Index.html
+++ b/Resources/Private/Templates/Statistic/Index.html
@@ -181,9 +181,9 @@
                                             <ul>
                                                 <f:for each="{feedItems}" as="item">
                                                     <li>
-                                                        <f:link.external target="_blank" uri="{item.link}">
+                                                        <a target="_blank" href="{item.link}">
                                                             {item.title}
-                                                        </f:link.external>
+                                                        </a>
                                                         <f:if condition="{item.date}">
                                                             <i>{item.date -> f:format.date(format:'d.m.Y')}</i>
                                                         </f:if>


### PR DESCRIPTION
The ViewHelper `<f:link.external>` seems to have problems with https-URLs and security news from RSS feed are linked like this `http://https//typo3.org/...`

The RSS feed contains full URLs, so I think it should be save to use only `<a>` tags instead of `<f:link.external>`