### PR TITLE
[BUGFIX] remove duplicated hidden in clients TCA

### DIFF
--- a/Configuration/TCA/tx_t3monitoring_domain_model_client.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_client.php
@@ -29,7 +29,7 @@ return [
         ],
     ],
     'palettes' => [
-        'paletteDomain' => ['showitem' => 'domain, secret, --linebreak--, basic_auth_username, basic_auth_password, hidden'],
+        'paletteDomain' => ['showitem' => 'domain, secret, --linebreak--, basic_auth_username, basic_auth_password'],
         'paletteVersions' => ['showitem' => 'php_version, mysql_version'],
         'paletteDiskSpace' => ['showitem' => 'disk_total_space, disk_free_space'],
     ],


### PR DESCRIPTION
There are two hidden fields in the clients. One in "General" tab and one in "Access''. I removed the one in "General" tab.