### PR TITLE
[BUGFIX] Update IP hint formatting in Administration view

### DIFF
--- a/Resources/Private/Templates/Statistic/Administration.html
+++ b/Resources/Private/Templates/Statistic/Administration.html
@@ -6,7 +6,7 @@
 	<h1>{f:translate(key:'view.administration')}</h1>
 	<f:if condition="{emConfiguration.ipHint}">
 		<div class="alert alert-info">
-			<f:translate key="administration.ipHint" arguments="{0:emConfiguration.ipHint}" />
+			<f:format.raw><f:translate key="administration.ipHint" arguments="{0:emConfiguration.ipHint}" /></f:format.raw>
 		</div>
 	</f:if>
 


### PR DESCRIPTION
The IP address hint in Administration view contains `<code>` in its locallang string. This text is shown in the browser instead of rendered as HTML:
> ![before](https://user-images.githubusercontent.com/16088567/43314895-9f8dbc6a-9194-11e8-94c8-127913fb48df.png)

This pull request changes that and the IP address is shown correctly inside the `<code>` tag:
> ![after](https://user-images.githubusercontent.com/16088567/43314894-9f6477ba-9194-11e8-9c9a-590525b9572f.png)


If you have security concerns with this change, because HTML from locallang will be shown in the browser, the alternative solution could be to remove the `<code>` tag from the locallang file or replace them with quotes.
