### PR TITLE
TYPO3 v9: Error during the saving process

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -23,6 +23,12 @@ call_user_func(
                     'labels' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang_t3monitor.xlf',
                 ]
             );
+
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_t3monitoring_domain_model_client');
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_t3monitoring_domain_model_core');
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_t3monitoring_domain_model_extension');
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_t3monitoring_domain_model_sla');
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_t3monitoring_domain_model_tag');
         }
     }
 );


### PR DESCRIPTION
When saving in TYPO3 v9 an error message is generated telling you that it is not allowed to save the record. This error has been fixed with my change.