### PR TITLE
[FEATURE] Update client model to support multiple tags

### DIFF
--- a/Classes/Domain/Model/Client.php
+++ b/Classes/Domain/Model/Client.php
@@ -134,7 +134,7 @@ class Client extends AbstractEntity
     protected $sla = null;
 
     /**
-     * @var \T3Monitor\T3monitoring\Domain\Model\Tag
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\T3Monitor\T3monitoring\Domain\Model\Tag>
      * @lazy
      */
     protected $tag = null;

--- a/Configuration/TCA/tx_t3monitoring_domain_model_client.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_client.php
@@ -119,15 +119,13 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.tag',
             'config' => [
+                'enableMultiSelectFilterTextfield' => 1,
                 'type' => 'select',
-                'renderType' => 'selectSingle',
+                'default' => '',
+                'renderType' => 'selectMultipleSideBySide',
                 'foreign_table' => 'tx_t3monitoring_domain_model_tag',
                 'minitems' => 0,
-                'maxitems' => 1,
-                'default' => 0,
-                'items' => [
-                    ['', 0]
-                ]
+                'maxitems' => 10,
             ],
         ],
         'php_version' => [

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -211,7 +211,7 @@
 				<source>Description</source>
 			</trans-unit>
 			<trans-unit id="tx_t3monitoring_domain_model_tag">
-				<source>Tag</source>
+				<source>Tags</source>
 			</trans-unit>
 			<trans-unit id="tx_t3monitoring_domain_model_tag.title">
 				<source>Title</source>

--- a/Resources/Private/Templates/Client/Show.html
+++ b/Resources/Private/Templates/Client/Show.html
@@ -60,7 +60,9 @@
 						<tr>
 							<th><i class="fa fa-tags fa-fw"></i> {f:translate(key:'tx_t3monitoring_domain_model_tag')}</th>
 							<td>
-								<f:link.action action="show" controller="Tag" arguments="{tag:client.tag}">{client.tag.title}</f:link.action>
+								<f:for each="{client.tag}" as="single_tag" iteration="iter">
+									<f:link.action action="show" controller="Tag" arguments="{tag:single_tag}">{single_tag.title}<f:if condition="!{iter.isLast}">,</f:if></f:link.action>
+								</f:for>
 							</td>
 						</tr>
 					</f:if>

--- a/Resources/Private/Templates/Statistic/Index.html
+++ b/Resources/Private/Templates/Statistic/Index.html
@@ -378,10 +378,12 @@
                                                         <td class="text-nowrap">
                                                             <f:if condition="{client.tag}">
                                                                 <f:then>
-                                                                    <f:link.action action="show" controller="Tag"
-                                                                                   arguments="{tag:client.tag}">
-                                                                        {client.tag.title}
-                                                                    </f:link.action>
+                                                                    <f:for each="{client.tag}" as="single_tag" iteration="iter">
+                                                                        <f:link.action action="show" controller="Tag"
+                                                                                       arguments="{tag:single_tag}">
+                                                                            {single_tag.title}<f:if condition="!{iter.isLast}">,</f:if>
+                                                                        </f:link.action>
+                                                                    </f:for>
                                                                 </f:then>
                                                                 <f:else>-</f:else>
                                                             </f:if>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -28,7 +28,7 @@ CREATE TABLE tx_t3monitoring_domain_model_client (
 	extensions int(11) unsigned DEFAULT '0' NOT NULL,
 	core int(11) unsigned DEFAULT '0',
 	sla int(11) unsigned DEFAULT '0',
-	tag int(11) unsigned DEFAULT '0',
+	tag tinytext,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Allow clients to have multiple tags. Related issue: #133 

The tag column must be migrated via the important actions compare database wizard. 