### PR TITLE
[BUGFIX] change update_comment to text to prevent data too long error

### DIFF
--- a/Configuration/TCA/tx_t3monitoring_domain_model_extension.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_extension.php
@@ -102,8 +102,9 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.update_comment',
             'config' => [
-                'type' => 'input',
-                'size' => 30,
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 15,
                 'eval' => 'trim'
             ],
         ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -56,7 +56,7 @@ CREATE TABLE tx_t3monitoring_domain_model_extension (
 	description text NOT NULL,
 	last_updated datetime DEFAULT NULL,
 	author_name varchar(255) DEFAULT '' NOT NULL,
-	update_comment varchar(255) DEFAULT '' NOT NULL,
+	update_comment text NOT NULL,
 	state int(11) DEFAULT '0' NOT NULL,
 	category int(11) DEFAULT '0' NOT NULL,
 	version_integer int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Fixes an error where the update_comment is longer than 255 chars and yields an `Data too long for column 'update_comment'` error during the import
