### PR TITLE
[TASK] TCA: remove 'exclude' => true

### DIFF
--- a/Configuration/TCA/tx_t3monitoring_domain_model_client.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_client.php
@@ -36,14 +36,12 @@ return [
     ],
     'columns' => [
         'hidden' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
             ],
         ],
         'title' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.title',
             'config' => [
                 'type' => 'input',
@@ -53,7 +51,6 @@ return [
             ],
         ],
         'domain' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.domain',
             'config' => [
                 'type' => 'input',
@@ -63,7 +60,6 @@ return [
             ],
         ],
         'secret' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.secret',
             'config' => [
                 'type' => 'input',
@@ -74,7 +70,6 @@ return [
             ],
         ],
         'basic_auth_username' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.basic_auth_username',
             'config' => [
                 'type' => 'input',
@@ -83,7 +78,6 @@ return [
             ],
         ],
         'basic_auth_password' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.basic_auth_password',
             'config' => [
                 'type' => 'input',
@@ -92,7 +86,6 @@ return [
             ],
         ],
         'host_header' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.hostHeader',
             'config' => [
                 'type' => 'input',
@@ -102,14 +95,12 @@ return [
             ],
         ],
         'ignore_cert_errors' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.ignoreCertErrors',
             'config' => [
                 'type' => 'check',
             ],
         ],
         'force_ip_resolve' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.forceIpResolve',
             'config' => [
                 'type' => 'select',
@@ -126,7 +117,6 @@ return [
             ],
         ],
         'email' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.email',
             'config' => [
                 'type' => 'input',
@@ -136,7 +126,6 @@ return [
             ],
         ],
         'sla' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.sla',
             'config' => [
                 'type' => 'select',
@@ -151,7 +140,6 @@ return [
             ],
         ],
         'tag' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.tag',
             'config' => [
                 'enableMultiSelectFilterTextfield' => 1,
@@ -164,7 +152,6 @@ return [
             ],
         ],
         'php_version' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.php_version',
             'config' => [
                 'readOnly' => true,
@@ -174,7 +161,6 @@ return [
             ],
         ],
         'mysql_version' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.mysql_version',
             'config' => [
                 'readOnly' => true,
@@ -184,7 +170,6 @@ return [
             ],
         ],
         'disk_total_space' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.disk_total_space',
             'config' => [
                 'readOnly' => true,
@@ -194,7 +179,6 @@ return [
             ],
         ],
         'disk_free_space' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.disk_free_space',
             'config' => [
                 'readOnly' => true,
@@ -204,7 +188,6 @@ return [
             ],
         ],
         'insecure_core' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.insecure_core',
             'config' => [
                 'readOnly' => true,
@@ -213,7 +196,6 @@ return [
             ],
         ],
         'outdated_core' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.outdated_core',
             'config' => [
                 'readOnly' => true,
@@ -222,7 +204,6 @@ return [
             ],
         ],
         'insecure_extensions' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.insecure_extensions',
             'config' => [
                 'readOnly' => true,
@@ -232,7 +213,6 @@ return [
             ],
         ],
         'outdated_extensions' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.outdated_extensions',
             'config' => [
                 'readOnly' => true,
@@ -242,7 +222,6 @@ return [
             ],
         ],
         'error_message' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.error_message',
             'config' => [
                 'readOnly' => true,
@@ -253,7 +232,6 @@ return [
             ],
         ],
         'extra_info' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang_db.xlf:tx_t3monitoring_domain_model_client.extra_info',
             'config' => [
                 'readOnly' => true,
@@ -264,7 +242,6 @@ return [
             ],
         ],
         'extra_warning' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang_db.xlf:tx_t3monitoring_domain_model_client.extra_warning',
             'config' => [
                 'readOnly' => true,
@@ -275,7 +252,6 @@ return [
             ],
         ],
         'extra_danger' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang_db.xlf:tx_t3monitoring_domain_model_client.extra_danger',
             'config' => [
                 'readOnly' => true,
@@ -286,7 +262,6 @@ return [
             ],
         ],
         'last_successful_import' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.last_successful_import',
             'config' => [
                 'readOnly' => true,
@@ -298,7 +273,6 @@ return [
             ],
         ],
         'extensions' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.extensions',
             'config' => [
                 'readOnly' => true,
@@ -315,7 +289,6 @@ return [
             ],
         ],
         'core' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_client.core',
             'config' => [
                 'readOnly' => true,

--- a/Configuration/TCA/tx_t3monitoring_domain_model_core.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_core.php
@@ -25,7 +25,6 @@ return [
     ],
     'columns' => [
         'version' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.version',
             'config' => [
                 'type' => 'input',
@@ -34,7 +33,6 @@ return [
             ],
         ],
         'insecure' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.insecure',
             'config' => [
                 'type' => 'check',
@@ -42,7 +40,6 @@ return [
             ],
         ],
         'next_secure_version' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.next_secure_version',
             'config' => [
                 'type' => 'input',
@@ -51,7 +48,6 @@ return [
             ],
         ],
         'type' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.type',
             'config' => [
                 'type' => 'select',
@@ -69,7 +65,6 @@ return [
             ],
         ],
         'release_date' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.release_date',
             'config' => [
                 'dbType' => 'datetime',
@@ -80,7 +75,6 @@ return [
             ],
         ],
         'latest' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.latest',
             'config' => [
                 'type' => 'input',
@@ -89,7 +83,6 @@ return [
             ],
         ],
         'stable' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.stable',
             'config' => [
                 'type' => 'input',
@@ -98,7 +91,6 @@ return [
             ],
         ],
         'is_stable' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.is_stable',
             'config' => [
                 'type' => 'check',
@@ -106,7 +98,6 @@ return [
             ],
         ],
         'is_active' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.is_active',
             'config' => [
                 'type' => 'check',
@@ -114,7 +105,6 @@ return [
             ],
         ],
         'is_latest' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.is_latest',
             'config' => [
                 'type' => 'check',
@@ -122,7 +112,6 @@ return [
             ],
         ],
         'version_integer' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.version_integer',
             'config' => [
                 'type' => 'input',
@@ -131,7 +120,6 @@ return [
             ],
         ],
         'is_used' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.is_used',
             'config' => [
                 'type' => 'check',
@@ -140,7 +128,6 @@ return [
             ],
         ],
         'is_official' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_core.is_official',
             'config' => [
                 'type' => 'check',

--- a/Configuration/TCA/tx_t3monitoring_domain_model_extension.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_extension.php
@@ -25,7 +25,6 @@ return [
     ],
     'columns' => [
         'name' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.name',
             'config' => [
                 'type' => 'input',
@@ -34,7 +33,6 @@ return [
             ],
         ],
         'version' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.version',
             'config' => [
                 'type' => 'input',
@@ -43,7 +41,6 @@ return [
             ],
         ],
         'insecure' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.insecure',
             'config' => [
                 'type' => 'check',
@@ -51,7 +48,6 @@ return [
             ],
         ],
         'next_secure_version' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.next_secure_version',
             'config' => [
                 'type' => 'input',
@@ -60,7 +56,6 @@ return [
             ],
         ],
         'title' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.title',
             'config' => [
                 'type' => 'input',
@@ -69,7 +64,6 @@ return [
             ],
         ],
         'description' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.description',
             'config' => [
                 'type' => 'text',
@@ -79,7 +73,6 @@ return [
             ],
         ],
         'last_updated' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.last_updated',
             'config' => [
                 'type' => 'input',
@@ -90,7 +83,6 @@ return [
             ],
         ],
         'author_name' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.author_name',
             'config' => [
                 'type' => 'input',
@@ -99,7 +91,6 @@ return [
             ],
         ],
         'update_comment' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.update_comment',
             'config' => [
                 'type' => 'text',
@@ -109,7 +100,6 @@ return [
             ],
         ],
         'state' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.state',
             'config' => [
                 'type' => 'select',
@@ -123,7 +113,6 @@ return [
             ],
         ],
         'category' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.category',
             'config' => [
                 'type' => 'select',
@@ -137,7 +126,6 @@ return [
             ],
         ],
         'version_integer' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.version_integer',
             'config' => [
                 'type' => 'input',
@@ -146,7 +134,6 @@ return [
             ],
         ],
         'is_used' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.is_used',
             'config' => [
                 'type' => 'check',
@@ -154,7 +141,6 @@ return [
             ],
         ],
         'is_official' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.is_official',
             'config' => [
                 'type' => 'check',
@@ -162,7 +148,6 @@ return [
             ],
         ],
         'is_modified' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.is_modified',
             'config' => [
                 'type' => 'check',
@@ -170,7 +155,6 @@ return [
             ],
         ],
         'is_latest' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.is_latest',
             'config' => [
                 'type' => 'check',
@@ -178,7 +162,6 @@ return [
             ],
         ],
         'last_bugfix_release' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.last_bugfix_release',
             'config' => [
                 'type' => 'input',
@@ -187,7 +170,6 @@ return [
             ],
         ],
         'last_minor_release' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.last_minor_release',
             'config' => [
                 'type' => 'input',
@@ -196,7 +178,6 @@ return [
             ],
         ],
         'last_major_release' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.last_major_release',
             'config' => [
                 'type' => 'input',
@@ -205,7 +186,6 @@ return [
             ],
         ],
         'serialized_dependencies' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_extension.serialized_dependencies',
             'config' => [
                 'type' => 'text',

--- a/Configuration/TCA/tx_t3monitoring_domain_model_sla.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_sla.php
@@ -25,14 +25,12 @@ return [
     ],
     'columns' => [
         'hidden' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
             ],
         ],
         'title' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_sla.title',
             'config' => [
                 'type' => 'input',
@@ -41,7 +39,6 @@ return [
             ],
         ],
         'description' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_sla.description',
             'config' => [
                 'type' => 'text',

--- a/Configuration/TCA/tx_t3monitoring_domain_model_tag.php
+++ b/Configuration/TCA/tx_t3monitoring_domain_model_tag.php
@@ -25,14 +25,12 @@ return [
     ],
     'columns' => [
         'hidden' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
             ],
         ],
         'title' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_tag.title',
             'config' => [
                 'type' => 'input',
@@ -42,7 +40,6 @@ return [
             ],
         ],
         'description' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:t3monitoring/Resources/Private/Language/locallang.xlf:tx_t3monitoring_domain_model_tag.description',
             'config' => [
                 'type' => 'text',


### PR DESCRIPTION
This patch removes all exclude options of
TCA columns.

The following regex was used to remove the lines:
^.*\b(exclude)\b.*$\n

Fixes: #165