### PR TITLE
[FEATURE] Add extension key in extra section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
-      "web-dir": ".Build/Web"
+      "web-dir": ".Build/Web",
+      "extension-key": "t3monitoring"
     }
   }
 }


### PR DESCRIPTION
Add the extension key in the composer.json extra section for future TYPO3 versions (https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra).