### PR TITLE
[BUGFIX] Fix text formatting in client detail view

### DIFF
--- a/Resources/Private/Templates/Client/Show.html
+++ b/Resources/Private/Templates/Client/Show.html
@@ -229,7 +229,7 @@
 			<f:for each="{data}" as="value" key="key">
 				<tr class="{cssClass}">
 					<th style="width: 20%;">{key}</th>
-					<td>{value}</td>
+					<td>{value -> f:format.html()}</td>
 				</tr>
 			</f:for>
 		</table>


### PR DESCRIPTION
Text for extra dangers, extra warnings and extra info is sometimes not just plain text but HTML. Therefore it needs to be rendered as HTML.