### PR TITLE
Add event for client data import

### DIFF
--- a/Classes/Event/ImportClientDataEvent.php
+++ b/Classes/Event/ImportClientDataEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3Monitor\T3monitoring\Event;
+
+final class ImportClientDataEvent
+{
+    private array $json;
+    private array $row;
+    private array $update;
+
+    public function __construct(array $json, array $row, array $update)
+    {
+        $this->json = $json;
+        $this->row = $row;
+        $this->update = $update;
+    }
+
+    public function getJson(): array
+    {
+        return $this->json;
+    }
+
+    public function getRow(): array
+    {
+        return $this->row;
+    }
+
+    public function getUpdate(): array
+    {
+        return $this->update;
+    }
+
+    public function setUpdate(array $update): void
+    {
+        $this->update = $update;
+    }
+}

--- a/Classes/Service/Import/BaseImport.php
+++ b/Classes/Service/Import/BaseImport.php
@@ -8,7 +8,9 @@ namespace T3Monitor\T3monitoring\Service\Import;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use T3Monitor\T3monitoring\Domain\Model\Dto\EmMonitoringConfiguration;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -23,6 +25,8 @@ class BaseImport
     /** @var Registry */
     protected $registry;
 
+    protected EventDispatcherInterface $eventDispatcher;
+
     /**
      * Constructor
      */
@@ -30,6 +34,8 @@ class BaseImport
     {
         $this->emConfiguration = GeneralUtility::makeInstance(EmMonitoringConfiguration::class);
         $this->registry = GeneralUtility::makeInstance(Registry::class);
+        $this->eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+
     }
 
     /**

--- a/Classes/Service/Import/ClientImport.php
+++ b/Classes/Service/Import/ClientImport.php
@@ -11,6 +11,7 @@ namespace T3Monitor\T3monitoring\Service\Import;
 
 use Exception;
 use T3Monitor\T3monitoring\Domain\Model\Extension;
+use T3Monitor\T3monitoring\Event\ImportClientDataEvent;
 use T3Monitor\T3monitoring\Notification\EmailNotification;
 use T3Monitor\T3monitoring\Service\DataIntegrity;
 use TYPO3\CMS\Core\Database\Connection;
@@ -125,6 +126,11 @@ class ClientImport extends BaseImport
                 'extensions' => $this->handleExtensionRelations($row['uid'], (array)$json['extensions']),
                 'error_count' => 0
             ];
+
+            $event = $this->eventDispatcher->dispatch(
+                new ImportClientDataEvent($json, $row, $update)
+            );
+            $update = $event->getUpdate();
 
             $this->addExtraData($json, $update, 'info');
             $this->addExtraData($json, $update, 'warning');


### PR DESCRIPTION
The t3monitoring_client is easyily extendable with custom data providers by registering them to the providers array: `$GLOBALS['TYPO3_CONF_VARS']['EXT']['t3monitoring_client']['provider'][]`.

To import the data from custom providers, we would like to add an PSR-14 event to the ClientImport class. This way we don't need to override the whole class. 